### PR TITLE
fix: Fail-closed proxy health, config validation, pipe deadlock

### DIFF
--- a/src/secrets_proxy/cli.py
+++ b/src/secrets_proxy/cli.py
@@ -73,6 +73,9 @@ def main(argv: list[str] | None = None) -> int:
             print("Error: no command specified. Usage: secrets-proxy run --config secrets.json -- <command>", file=sys.stderr)
             return 1
 
+        from .launcher import _check_config_permissions
+        _check_config_permissions(args.config)
+
         config = load_config(args.config, allow_net=args.allow_net)
         config.proxy_port = args.port
 

--- a/src/secrets_proxy/config.py
+++ b/src/secrets_proxy/config.py
@@ -228,11 +228,34 @@ def load_config(
         validate_secret_name(name)
 
         if isinstance(entry_data, str):
-            # Simple format: {"OPENAI_API_KEY": "sk-real-key"}
-            # No host restriction, no injection config
             raise ValueError(
                 f"Secret '{name}' must be a dict with 'value' and 'hosts' keys, "
                 f"not a plain string. Secrets without host restrictions are not allowed."
+            )
+
+        if not isinstance(entry_data, dict):
+            raise TypeError(
+                f"Secret '{name}': expected a dict, got {type(entry_data).__name__}"
+            )
+
+        # Validate required keys with clear messages
+        if "value" not in entry_data:
+            raise ValueError(
+                f"Secret '{name}' is missing required key 'value'."
+            )
+        if "hosts" not in entry_data:
+            raise ValueError(
+                f"Secret '{name}' is missing required key 'hosts'. "
+                f"Every secret must be scoped to specific destination hosts."
+            )
+        if not isinstance(entry_data["hosts"], list):
+            raise TypeError(
+                f"Secret '{name}': 'hosts' must be a list of hostnames, "
+                f"got {type(entry_data['hosts']).__name__}"
+            )
+        if not entry_data["hosts"]:
+            raise ValueError(
+                f"Secret '{name}': 'hosts' list cannot be empty."
             )
 
         inject = entry_data.get("inject", {})


### PR DESCRIPTION
## Summary
- **Fail-closed**: Background thread monitors mitmproxy — kills sandbox if proxy dies
- **No pipe deadlock**: Use `subprocess.DEVNULL` instead of `PIPE` for mitmproxy output
- **Startup check**: Verify `mitmdump` is on PATH before attempting anything
- **Config validation**: Required keys (`value`, `hosts`) validated with clear error messages
- **Permission warning**: Warns if config file is readable by group/others
- **Sandbox as Popen**: Run sandbox command via `Popen` so health monitor can terminate it

## Test plan
- [ ] Kill mitmproxy during sandbox run — verify sandbox is killed too
- [ ] Remove mitmdump from PATH — verify clear error message
- [ ] Test config with missing `value` key — verify helpful error
- [ ] Test config with empty `hosts` list — verify rejection
- [ ] Set config to 644 — verify permission warning

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)