### PR TITLE
docs: clarify Sprite transparency + reframe CA trust (#29, #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When running untrusted or semi-trusted code in sandboxes (Sprites, Docker, VMs),
 
 | Property | How |
 |----------|-----|
-| **Code is oblivious** | Transparent proxy (Docker) or regular proxy + nftables kill switch (Sprites) — code doesn't need modification |
+| **Code is oblivious** | Transparent proxy (Docker, all clients) or regular proxy + nftables kill switch (Sprites, proxy-aware clients) |
 | **Most languages work** | Broad CA compatibility via `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS` |
 | **Secrets never in sandbox** | Placeholder tokens only; real values injected at proxy layer |
 | **Host-scoped secrets** | Each secret specifies which hosts it can be sent to |


### PR DESCRIPTION
## Summary
- **#29**: Clarify that Sprites use a fail-closed kill switch (nftables + protocol mismatch), not transparent redirection. Docker uses true transparent mode.
- **#31**: Reframe "universal CA trust" as "broad compatibility". Add Runtime Compatibility Matrix table (Python/curl tested, Node/Go expected, Java/Rust untested). Note certificate-pinning limitation.

## Changes
- `ARCHITECTURE.md`: Updated Design Goal #1, Sprites section, two-layer enforcement, CA trust section (+ compatibility matrix), comparison table, summary line
- `README.md`: Updated transparency row and language compatibility row

## Test plan
- [x] `pytest tests/` — 86 passed
- [ ] Review accuracy of kill switch description against actual nftables/mitmproxy behavior
- [ ] Verify compatibility matrix matches tested runtimes

Closes #29, closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)