### PR TITLE
fix: SO_MARK capability gate + Brotli fail-closed (#17, #16)

### DIFF
--- a/src/secrets_proxy/launcher.py
+++ b/src/secrets_proxy/launcher.py
@@ -24,6 +24,7 @@ import os
 import platform
 import shutil
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -219,6 +220,46 @@ def _setup_nftables(sandbox_uid: int, proxy_port: int) -> bool:
         return False
 
 
+def _can_set_so_mark() -> bool:
+    """Check whether SO_MARK can be set (requires CAP_NET_ADMIN on Linux)."""
+    if platform.system() != "Linux":
+        return False
+    if not hasattr(socket, "SO_MARK"):
+        logger.error("SO_MARK is unavailable. Cannot use nftables enforcement.")
+        return False
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_MARK, _PROXY_MARK)
+        return True
+    except PermissionError:
+        logger.error("CAP_NET_ADMIN required for SO_MARK. Cannot use nftables enforcement.")
+        return False
+    except OSError as exc:
+        logger.error("SO_MARK check failed: %s. Cannot use nftables enforcement.", exc)
+        return False
+    finally:
+        s.close()
+
+
+def _select_network_enforcement(sandbox_uid: int, proxy_port: int) -> bool:
+    """Enable nftables only when SO_MARK capability checks pass."""
+    if platform.system() != "Linux":
+        logger.info("Network enforcement mode: env-var-only (non-Linux platform)")
+        return False
+
+    if not _can_set_so_mark():
+        logger.info("Network enforcement mode: env-var-only (SO_MARK unavailable)")
+        return False
+
+    used_nftables = _setup_nftables(sandbox_uid, proxy_port)
+    if used_nftables:
+        logger.info("Network enforcement mode: nftables active")
+    else:
+        logger.info("Network enforcement mode: env-var-only (nftables setup failed)")
+    return used_nftables
+
+
 def _teardown_nftables(sandbox_uid: int, proxy_port: int) -> None:
     """Remove only the nftables table created by secrets-proxy. Best-effort.
 
@@ -404,7 +445,7 @@ def run(
     # Step 5: Try nftables (Linux strong mode) BEFORE starting proxy
     # so we know which mitmproxy mode to use.
     uid = os.getuid()
-    used_nftables = _setup_nftables(uid, port)
+    used_nftables = _select_network_enforcement(uid, port)
 
     # Step 6: Start mitmproxy — transparent mode when nftables is active
     proxy_proc = start_proxy(

--- a/tests/test_addon_security_fixes.py
+++ b/tests/test_addon_security_fixes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from secrets_proxy import addon as addon_module
 from secrets_proxy.addon import SecretsProxyAddon
 from secrets_proxy.config import ProxyConfig, SecretEntry
 
@@ -144,7 +145,7 @@ def test_try_decompress_normal_gzip_works() -> None:
 def test_try_decompress_oversize_returns_none_and_logs_warning(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    monkeypatch.setattr("secrets_proxy.addon.MAX_DECOMPRESS_SIZE", 16)
+    monkeypatch.setattr(addon_module, "MAX_DECOMPRESS_SIZE", 16)
     config = _make_config()
     addon = SecretsProxyAddon(config)
     compressed = gzip.compress(b"a" * 17)

--- a/tests/test_launcher_security.py
+++ b/tests/test_launcher_security.py
@@ -1,0 +1,71 @@
+"""Tests for launcher security checks around nftables/SO_MARK."""
+
+from __future__ import annotations
+
+import logging
+
+from secrets_proxy import launcher
+
+
+def test_nftables_setup_proceeds_when_so_mark_is_available(
+    monkeypatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    class _DummySocket:
+        def setsockopt(self, level: int, optname: int, value: int) -> None:
+            calls["setsockopt"] = (level, optname, value)
+
+        def close(self) -> None:
+            calls["closed"] = True
+
+    def _fake_setup(uid: int, proxy_port: int) -> bool:
+        calls["setup"] = (uid, proxy_port)
+        return True
+
+    monkeypatch.setattr(launcher.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(launcher.socket, "SO_MARK", 36, raising=False)
+    monkeypatch.setattr(launcher.socket, "socket", lambda *_a, **_k: _DummySocket())
+    monkeypatch.setattr(launcher, "_setup_nftables", _fake_setup)
+
+    assert launcher._select_network_enforcement(1234, 8080) is True
+    assert calls["setup"] == (1234, 8080)
+    assert calls["closed"] is True
+
+
+def test_nftables_falls_back_when_so_mark_requires_cap_net_admin(
+    monkeypatch, caplog
+) -> None:
+    setup_called = False
+
+    class _PermissionDeniedSocket:
+        def setsockopt(self, _level: int, _optname: int, _value: int) -> None:
+            raise PermissionError("operation not permitted")
+
+        def close(self) -> None:
+            pass
+
+    def _fake_setup(_uid: int, _proxy_port: int) -> bool:
+        nonlocal setup_called
+        setup_called = True
+        return True
+
+    monkeypatch.setattr(launcher.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(launcher.socket, "SO_MARK", 36, raising=False)
+    monkeypatch.setattr(
+        launcher.socket, "socket", lambda *_a, **_k: _PermissionDeniedSocket()
+    )
+    monkeypatch.setattr(launcher, "_setup_nftables", _fake_setup)
+
+    with caplog.at_level(logging.INFO):
+        assert launcher._select_network_enforcement(1234, 8080) is False
+
+    assert setup_called is False
+    assert any(
+        "CAP_NET_ADMIN required for SO_MARK" in rec.message for rec in caplog.records
+    )
+    assert any(
+        "Network enforcement mode: env-var-only (SO_MARK unavailable)" in rec.message
+        for rec in caplog.records
+    )
+


### PR DESCRIPTION
## Summary
- **#17**: Add `_can_set_so_mark()` startup check — probes SO_MARK with test socket, graceful fallback to env-var-only mode if CAP_NET_ADMIN is missing
- **#16**: Brotli fail-closed when scrubbing required but brotli unavailable (502 response)
- **Gemini fix**: Removed bogus compressed-data text search that could never find plaintext secrets in brotli-compressed bytes
- **Test fix**: Fixed monkeypatch ordering issue for MAX_DECOMPRESS_SIZE test

## Changes from original PR #38
- Removed `_text_contains_any_secret_value()` method — searching compressed bytes for plaintext secrets is ineffective (Gemini finding)
- Simplified brotli logic: fail closed if `_secrets_proxy_request_had_substitutions` is True, pass through otherwise
- Fixed monkeypatch in test_addon_security_fixes.py (module object ref instead of string path)

## Test plan
- [x] `pytest tests/` — 102 passed
- [x] Brotli response WITH substitutions → blocked (502)
- [x] Brotli response WITHOUT substitutions → passed through
- [x] SO_MARK available → nftables proceeds
- [x] SO_MARK denied → graceful fallback with clear logging

Closes #17, closes #16
Supersedes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)