### PR TITLE
refactor: consolidate addon logic into single production code path (#36)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,122 +32,16 @@ fi
 
 echo "[secrets-proxy] Starting (proxy_port=$PROXY_PORT, sandbox_uid=$SANDBOX_UID)"
 
-# ── Generate addon script from config ─────────────────────────
+# ── Generate config + addon via secrets_proxy init ────────────
 
-ADDON_SCRIPT=$(mktemp /tmp/secrets_proxy_addon_XXXXXX.py)
+SECRETS_PROXY_CONFIG_JSON=$(python3 -m secrets_proxy init \
+    --config-json "$SECRETS_PROXY_CONFIG_JSON" \
+    --sandbox-env /tmp/sandbox_env.sh)
+export SECRETS_PROXY_CONFIG_JSON
 
-python3 -c "
-import json, os, sys
+ADDON_SCRIPT=$(python3 -c "from pathlib import Path; import secrets_proxy.addon_entry; print(Path(secrets_proxy.addon_entry.__file__).resolve())")
 
-config_json = os.environ['SECRETS_PROXY_CONFIG_JSON']
-raw = json.loads(config_json)
-
-secrets_map = {}
-env_lines = []
-allowed_hosts = []
-
-for name, entry in raw.items():
-    import secrets as s
-    placeholder = f'SECRETS_PROXY_PLACEHOLDER_{s.token_hex(16)}'
-    secrets_map[placeholder] = {
-        'name': name,
-        'value': entry['value'],
-        'hosts': entry['hosts'],
-    }
-    env_lines.append(f'{name}={placeholder}')
-    for h in entry['hosts']:
-        allowed_hosts.append(h)
-
-# Write env file for sandbox
-with open('/tmp/sandbox_env.sh', 'w') as f:
-    for line in env_lines:
-        f.write(f'export {line}\n')
-
-# Write addon
-addon = '''
-import logging
-from mitmproxy import http
-
-logger = logging.getLogger(\"secrets-proxy-addon\")
-
-SECRETS = ''' + repr(secrets_map) + '''
-ALLOWED_HOSTS = ''' + repr(allowed_hosts) + '''
-
-def _host_allowed(host):
-    host = host.lower()
-    for p in ALLOWED_HOSTS:
-        if p.startswith(\"*.\"):
-            if host.endswith(p[1:]) or host == p[2:]:
-                return True
-        elif host == p.lower():
-            return True
-    return False
-
-def _host_matches(host, hosts):
-    host = host.lower()
-    for p in hosts:
-        if p.startswith(\"*.\"):
-            if host.endswith(p[1:]) or host == p[2:]:
-                return True
-        elif host == p.lower():
-            return True
-    return False
-
-def request(flow):
-    host = flow.request.pretty_host
-    if not _host_allowed(host):
-        flow.response = http.Response.make(403, f\"blocked: {host}\".encode())
-        logger.info(\"Blocked: %s\", host)
-        return
-    for hname in list(flow.request.headers.keys()):
-        hval = flow.request.headers[hname]
-        for placeholder, info in SECRETS.items():
-            if placeholder in hval and _host_matches(host, info[\"hosts\"]):
-                flow.request.headers[hname] = hval.replace(placeholder, info[\"value\"])
-                logger.info(\"Injected %s for %s\", info[\"name\"], host)
-                hval = flow.request.headers[hname]
-    if flow.request.content:
-        try:
-            body = flow.request.content.decode()
-            for placeholder, info in SECRETS.items():
-                if placeholder in body and _host_matches(host, info[\"hosts\"]):
-                    body = body.replace(placeholder, info[\"value\"])
-            flow.request.content = body.encode()
-        except:
-            pass
-
-def _redact_secret_values(text):
-    count = 0
-    for placeholder, info in SECRETS.items():
-        if info[\"value\"] in text:
-            text = text.replace(info[\"value\"], \"[REDACTED:\" + info[\"name\"] + \"]\")
-            count += 1
-            logger.warning(\"Redacted %s from response (reflection prevention)\", info[\"name\"])
-    return text, count
-
-def response(flow):
-    if flow.response is None:
-        return
-    for hname in list(flow.response.headers.keys()):
-        hval = flow.response.headers[hname]
-        new_val, n = _redact_secret_values(hval)
-        if n > 0:
-            flow.response.headers[hname] = new_val
-    if flow.response.content:
-        try:
-            body = flow.response.content.decode()
-            new_body, n = _redact_secret_values(body)
-            if n > 0:
-                flow.response.content = new_body.encode()
-                if \"Content-Length\" in flow.response.headers:
-                    flow.response.headers[\"Content-Length\"] = str(len(flow.response.content))
-        except:
-            pass
-'''
-print(addon)
-" > "$ADDON_SCRIPT"
-
-echo "[secrets-proxy] Addon script generated"
+echo "[secrets-proxy] Addon configured (using production SecretsProxyAddon)"
 
 # ── Create combined CA bundle ──────────────────────────────────
 
@@ -236,7 +130,7 @@ cleanup() {
     kill $PROXY_PID 2>/dev/null || true
     wait $PROXY_PID 2>/dev/null || true
     nft delete table inet "$NFT_CHAIN" 2>/dev/null || true
-    rm -f "$ADDON_SCRIPT" "$CA_BUNDLE" /tmp/sandbox_env.sh
+    rm -f "$CA_BUNDLE" /tmp/sandbox_env.sh
     echo "[secrets-proxy] Done"
 }
 trap cleanup EXIT

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,12 +34,11 @@ echo "[secrets-proxy] Starting (proxy_port=$PROXY_PORT, sandbox_uid=$SANDBOX_UID
 
 # ── Generate config + addon via secrets_proxy init ────────────
 
-SECRETS_PROXY_CONFIG_JSON=$(python3 -m secrets_proxy init \
-    --config-json "$SECRETS_PROXY_CONFIG_JSON" \
-    --sandbox-env /tmp/sandbox_env.sh)
+SECRETS_PROXY_CONFIG_JSON=$(echo "$SECRETS_PROXY_CONFIG_JSON" | \
+    python3 -m secrets_proxy init --sandbox-env /tmp/sandbox_env.sh)
 export SECRETS_PROXY_CONFIG_JSON
 
-ADDON_SCRIPT=$(python3 -c "from pathlib import Path; import secrets_proxy.addon_entry; print(Path(secrets_proxy.addon_entry.__file__).resolve())")
+ADDON_SCRIPT=$(python3 -c "from pathlib import Path; import secrets_proxy; print(Path(secrets_proxy.__file__).resolve().parent / 'addon_entry.py')")
 
 echo "[secrets-proxy] Addon configured (using production SecretsProxyAddon)"
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -143,15 +143,18 @@ trap cleanup EXIT
 echo "[secrets-proxy] Running as '$SANDBOX_USER': $*"
 echo "────────────────────────────────────────"
 
-# Source env vars and run as sandbox user
-su "$SANDBOX_USER" -c "
+# Source env vars and run as sandbox user without command-string interpolation.
+su "$SANDBOX_USER" -s /bin/bash -c '
+    set -euo pipefail
+    ca_bundle="$1"
+    shift
     source /tmp/sandbox_env.sh
-    export SSL_CERT_FILE=$CA_BUNDLE
-    export REQUESTS_CA_BUNDLE=$CA_BUNDLE
-    export NODE_EXTRA_CA_CERTS=$CA_BUNDLE
-    export CURL_CA_BUNDLE=$CA_BUNDLE
-    $*
-"
+    export SSL_CERT_FILE="$ca_bundle"
+    export REQUESTS_CA_BUNDLE="$ca_bundle"
+    export NODE_EXTRA_CA_CERTS="$ca_bundle"
+    export CURL_CA_BUNDLE="$ca_bundle"
+    exec "$@"
+' -- "$CA_BUNDLE" "$@"
 EXIT_CODE=$?
 
 echo "────────────────────────────────────────"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -90,6 +90,10 @@ if ! kill -0 $PROXY_PID 2>/dev/null; then
 fi
 echo "[secrets-proxy] mitmproxy started (PID $PROXY_PID, mark=0x$PROXY_MARK)"
 
+# Clear secrets from shell env — mitmproxy already consumed them at load time.
+# Without this, `su` would leak the full secret JSON to the sandbox user.
+unset SECRETS_PROXY_CONFIG_JSON
+
 # ── Set up nftables (INIT TIME — the "concrete walls") ────────
 # Uses inet family to cover both IPv4 and IPv6.
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -34,7 +34,7 @@ echo "[secrets-proxy] Starting (proxy_port=$PROXY_PORT, sandbox_uid=$SANDBOX_UID
 
 # ── Generate config + addon via secrets_proxy init ────────────
 
-SECRETS_PROXY_CONFIG_JSON=$(echo "$SECRETS_PROXY_CONFIG_JSON" | \
+SECRETS_PROXY_CONFIG_JSON=$(printf '%s' "$SECRETS_PROXY_CONFIG_JSON" | \
     python3 -m secrets_proxy init --sandbox-env /tmp/sandbox_env.sh)
 export SECRETS_PROXY_CONFIG_JSON
 

--- a/sprites/secrets-proxy-run.sh
+++ b/sprites/secrets-proxy-run.sh
@@ -35,12 +35,11 @@ fi
 
 # ── Generate config + addon via secrets_proxy init ────────────
 
-SECRETS_PROXY_CONFIG_JSON=$($PYTHON3 -m secrets_proxy init \
-    --config-json "$CONFIG_JSON" \
-    --sandbox-env /tmp/sandbox_env.sh)
+SECRETS_PROXY_CONFIG_JSON=$(echo "$CONFIG_JSON" | \
+    $PYTHON3 -m secrets_proxy init --sandbox-env /tmp/sandbox_env.sh)
 export SECRETS_PROXY_CONFIG_JSON
 
-ADDON_SCRIPT=$($PYTHON3 -c "from pathlib import Path; import secrets_proxy.addon_entry; print(Path(secrets_proxy.addon_entry.__file__).resolve())")
+ADDON_SCRIPT=$($PYTHON3 -c "from pathlib import Path; import secrets_proxy; print(Path(secrets_proxy.__file__).resolve().parent / 'addon_entry.py')")
 
 echo "[secrets-proxy] Addon configured (using production SecretsProxyAddon)"
 

--- a/sprites/secrets-proxy-run.sh
+++ b/sprites/secrets-proxy-run.sh
@@ -106,6 +106,10 @@ if ! kill -0 $PROXY_PID 2>/dev/null; then
 fi
 echo "[secrets-proxy] mitmproxy started (PID $PROXY_PID)"
 
+# Clear secrets from shell env — mitmproxy already consumed them at load time.
+# Without this, `su` would leak the full secret JSON to the sandbox user.
+unset SECRETS_PROXY_CONFIG_JSON
+
 # ── nftables setup (the "concrete walls") ──────────────────────
 # Uses inet family to cover both IPv4 and IPv6.
 

--- a/sprites/secrets-proxy-run.sh
+++ b/sprites/secrets-proxy-run.sh
@@ -35,7 +35,7 @@ fi
 
 # ── Generate config + addon via secrets_proxy init ────────────
 
-SECRETS_PROXY_CONFIG_JSON=$(echo "$CONFIG_JSON" | \
+SECRETS_PROXY_CONFIG_JSON=$(printf '%s' "$CONFIG_JSON" | \
     $PYTHON3 -m secrets_proxy init --sandbox-env /tmp/sandbox_env.sh)
 export SECRETS_PROXY_CONFIG_JSON
 

--- a/src/secrets_proxy/__main__.py
+++ b/src/secrets_proxy/__main__.py
@@ -17,14 +17,20 @@ def _handle_init(args: argparse.Namespace) -> int:
 
     Loads config, generates placeholders, writes sandbox env file,
     prints the SECRETS_PROXY_CONFIG_JSON value to stdout.
+
+    Config can be provided via --config-json (string), --config-file (path),
+    or stdin (piped). Prefer stdin or --config-file over --config-json to
+    avoid exposing secrets in process arguments visible to `ps`.
     """
     if args.config_json:
         raw = json.loads(args.config_json)
     elif args.config_file:
         with open(args.config_file) as f:
             raw = json.load(f)
+    elif not sys.stdin.isatty():
+        raw = json.load(sys.stdin)
     else:
-        print("Error: --config-json or --config-file required", file=sys.stderr)
+        print("Error: --config-json, --config-file, or stdin required", file=sys.stderr)
         return 1
 
     config = load_config_from_dict(raw)

--- a/src/secrets_proxy/__main__.py
+++ b/src/secrets_proxy/__main__.py
@@ -3,12 +3,41 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from pathlib import Path
 
-from .config import load_config
+from .config import load_config, load_config_from_dict
 from .launcher import _check_config_permissions, cleanup_nftables_chains, run
+
+
+def _handle_init(args: argparse.Namespace) -> int:
+    """Handle the 'init' subcommand.
+
+    Loads config, generates placeholders, writes sandbox env file,
+    prints the SECRETS_PROXY_CONFIG_JSON value to stdout.
+    """
+    if args.config_json:
+        raw = json.loads(args.config_json)
+    elif args.config_file:
+        with open(args.config_file) as f:
+            raw = json.load(f)
+    else:
+        print("Error: --config-json or --config-file required", file=sys.stderr)
+        return 1
+
+    config = load_config_from_dict(raw)
+
+    # Write sandbox env file (export NAME="PLACEHOLDER")
+    if args.sandbox_env:
+        with open(args.sandbox_env, "w") as f:
+            for entry in config.secrets.values():
+                f.write(f'export {entry.name}="{entry.placeholder}"\n')
+
+    # Print config JSON to stdout for shell capture
+    print(config.to_env_json())
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -53,6 +82,26 @@ def main(argv: list[str] | None = None) -> int:
         help="Command to run (after --)",
     )
 
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Generate placeholders and config JSON for shell scripts",
+    )
+    init_parser.add_argument(
+        "--config-json",
+        default=None,
+        help="Raw JSON config string",
+    )
+    init_parser.add_argument(
+        "--config-file",
+        default=None,
+        help="Path to JSON config file",
+    )
+    init_parser.add_argument(
+        "--sandbox-env",
+        default=None,
+        help="Path to write sandbox env file (export NAME=PLACEHOLDER)",
+    )
+
     subparsers.add_parser(
         "cleanup", help="Clean up stale secrets-proxy nftables chains"
     )
@@ -81,6 +130,9 @@ def main(argv: list[str] | None = None) -> int:
 
         ca_path = Path(args.ca_bundle) if args.ca_bundle else None
         return run(config, cmd, ca_bundle_path=ca_path)
+
+    if args.command == "init":
+        return _handle_init(args)
 
     if args.command == "cleanup":
         cleaned = cleanup_nftables_chains()

--- a/src/secrets_proxy/__main__.py
+++ b/src/secrets_proxy/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import shlex
 import sys
 from pathlib import Path
 
@@ -35,11 +36,11 @@ def _handle_init(args: argparse.Namespace) -> int:
 
     config = load_config_from_dict(raw)
 
-    # Write sandbox env file (export NAME="PLACEHOLDER")
+    # Write sandbox env file (export NAME=<shell-escaped placeholder>)
     if args.sandbox_env:
         with open(args.sandbox_env, "w") as f:
             for entry in config.secrets.values():
-                f.write(f'export {entry.name}="{entry.placeholder}"\n')
+                f.write(f'export {entry.name}={shlex.quote(entry.placeholder)}\n')
 
     # Print config JSON to stdout for shell capture
     print(config.to_env_json())

--- a/src/secrets_proxy/addon_entry.py
+++ b/src/secrets_proxy/addon_entry.py
@@ -41,7 +41,7 @@ def _load_config_from_env() -> ProxyConfig:
     raw_json = os.environ.pop("SECRETS_PROXY_CONFIG_JSON")
     data = json.loads(raw_json)
 
-    config = ProxyConfig()
+    config = ProxyConfig(allow_ip_literals=data.get("allow_ip_literals", False))
     secrets_data = data.get("secrets", {})
     for placeholder, info in secrets_data.items():
         entry = SecretEntry(

--- a/src/secrets_proxy/addon_entry.py
+++ b/src/secrets_proxy/addon_entry.py
@@ -1,0 +1,65 @@
+"""Thin mitmproxy entry point for secrets-proxy.
+
+Loaded by: mitmdump -s addon_entry.py
+
+Reads SECRETS_PROXY_CONFIG_JSON from the environment, builds a ProxyConfig
+via load_config_from_dict(), and instantiates the production SecretsProxyAddon.
+This ensures all deployment paths (launcher, Docker, Sprites) use the same
+addon code with full security features (compression, JSON escaping, URL
+encoding, WebSocket blocking, Brotli fail-closed, decompression limits).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from .addon import SecretsProxyAddon
+from .config import ProxyConfig, SecretEntry, load_config_from_dict
+
+logger = logging.getLogger("secrets-proxy")
+
+
+def _load_config_from_env() -> ProxyConfig:
+    """Load ProxyConfig from the SECRETS_PROXY_CONFIG_JSON env var.
+
+    Expected JSON format (produced by ProxyConfig.to_env_json()):
+    {
+        "secrets": {
+            "PLACEHOLDER_HEX": {
+                "name": "SECRET_NAME",
+                "value": "real-value",
+                "hosts": ["api.example.com"]
+            }
+        },
+        "allowed_hosts": ["api.example.com", ...]
+    }
+
+    The env var is popped immediately so child processes don't inherit it.
+    """
+    raw_json = os.environ.pop("SECRETS_PROXY_CONFIG_JSON")
+    data = json.loads(raw_json)
+
+    config = ProxyConfig()
+    secrets_data = data.get("secrets", {})
+    for placeholder, info in secrets_data.items():
+        entry = SecretEntry(
+            name=info["name"],
+            placeholder=placeholder,
+            value=info["value"],
+            hosts=info["hosts"],
+        )
+        config.secrets[info["name"]] = entry
+        config._placeholder_to_secret[placeholder] = entry
+        for host in info["hosts"]:
+            config.allowed_hosts.add(host)
+
+    for host in data.get("allowed_hosts", []):
+        config.allowed_hosts.add(host)
+
+    return config
+
+
+config = _load_config_from_env()
+addons = [SecretsProxyAddon(config)]

--- a/src/secrets_proxy/addon_entry.py
+++ b/src/secrets_proxy/addon_entry.py
@@ -2,8 +2,8 @@
 
 Loaded by: mitmdump -s addon_entry.py
 
-Reads SECRETS_PROXY_CONFIG_JSON from the environment, builds a ProxyConfig
-via load_config_from_dict(), and instantiates the production SecretsProxyAddon.
+Reads SECRETS_PROXY_CONFIG_JSON from the environment, builds a ProxyConfig,
+and instantiates the production SecretsProxyAddon.
 This ensures all deployment paths (launcher, Docker, Sprites) use the same
 addon code with full security features (compression, JSON escaping, URL
 encoding, WebSocket blocking, Brotli fail-closed, decompression limits).
@@ -15,8 +15,8 @@ import json
 import logging
 import os
 
-from .addon import SecretsProxyAddon
-from .config import ProxyConfig, SecretEntry, load_config_from_dict
+from secrets_proxy.addon import SecretsProxyAddon
+from secrets_proxy.config import ProxyConfig, SecretEntry
 
 logger = logging.getLogger("secrets-proxy")
 

--- a/src/secrets_proxy/config.py
+++ b/src/secrets_proxy/config.py
@@ -169,6 +169,7 @@ class ProxyConfig:
         return json.dumps({
             "secrets": secrets_data,
             "allowed_hosts": sorted(self.allowed_hosts),
+            "allow_ip_literals": self.allow_ip_literals,
         })
 
     def find_secret_for_placeholder(

--- a/src/secrets_proxy/config.py
+++ b/src/secrets_proxy/config.py
@@ -57,6 +57,9 @@ def _validate_host_pattern(pattern: str) -> None:
     - Wildcards must start with '*.' (not just '*')
     - Hostname must use valid characters
     """
+    if not pattern:
+        raise ValueError("Host pattern cannot be empty.")
+
     if pattern.startswith("*"):
         if not pattern.startswith("*."):
             raise ValueError(
@@ -181,21 +184,62 @@ class ProxyConfig:
         having addon_entry.py manually build ProxyConfig internals.
         """
         data = json.loads(env_json)
-        config = cls(allow_ip_literals=data.get("allow_ip_literals", False))
-        secrets_data = data.get("secrets", {})
-        for placeholder, info in secrets_data.items():
-            entry = SecretEntry(
-                name=info["name"],
-                placeholder=placeholder,
-                value=info["value"],
-                hosts=info["hosts"],
-            )
-            config.secrets[info["name"]] = entry
-            config._placeholder_to_secret[placeholder] = entry
-            for host in info["hosts"]:
-                config.allowed_hosts.add(host)
 
-        for host in data.get("allowed_hosts", []):
+        if not isinstance(data, dict):
+            raise TypeError("Invalid env config: top-level JSON value must be an object.")
+
+        allow_ip_literals = data.get("allow_ip_literals", False)
+        if not isinstance(allow_ip_literals, bool):
+            raise TypeError("Invalid env config: 'allow_ip_literals' must be a boolean.")
+
+        secrets_data = data.get("secrets", {})
+        if not isinstance(secrets_data, dict):
+            raise TypeError("Invalid env config: 'secrets' must be an object.")
+
+        raw: dict[str, dict[str, object]] = {}
+        for placeholder, info in secrets_data.items():
+            if not isinstance(placeholder, str):
+                raise TypeError("Invalid env config: secret placeholder keys must be strings.")
+            if not placeholder:
+                raise ValueError("Invalid env config: secret placeholders cannot be empty.")
+            if not isinstance(info, dict):
+                raise TypeError(
+                    f"Invalid env config: secret entry for placeholder '{placeholder}' must be an object."
+                )
+
+            name = info.get("name")
+            if not isinstance(name, str):
+                raise TypeError(
+                    f"Invalid env config: secret entry for placeholder '{placeholder}' is missing string 'name'."
+                )
+            if name in raw:
+                raise ValueError(
+                    f"Invalid env config: duplicate secret name '{name}' across placeholders."
+                )
+            if "value" not in info or "hosts" not in info:
+                raise ValueError(
+                    f"Invalid env config: secret '{name}' must include 'value' and 'hosts'."
+                )
+
+            raw[name] = {
+                "value": info["value"],
+                "hosts": info["hosts"],
+                "placeholder": placeholder,
+            }
+
+        config = _build_config_from_dict(
+            raw,
+            allow_ip_literals=allow_ip_literals,
+        )
+
+        allowed_hosts = data.get("allowed_hosts", [])
+        if not isinstance(allowed_hosts, list):
+            raise TypeError("Invalid env config: 'allowed_hosts' must be a list.")
+        for host in allowed_hosts:
+            if not isinstance(host, str):
+                raise TypeError("Invalid env config: all allowed_hosts entries must be strings.")
+            host = _sanitize_host(host)
+            _validate_host_pattern(host)
             config.allowed_hosts.add(host)
 
         return config
@@ -239,7 +283,13 @@ def _build_config_from_dict(
     Shared implementation for load_config() and load_config_from_dict().
     All validation (secret names, host patterns) is applied here.
     """
+    if not isinstance(raw, dict):
+        raise TypeError(
+            f"Config must be a JSON object mapping secret names to entries, got {type(raw).__name__}."
+        )
+
     config = ProxyConfig(allow_ip_literals=allow_ip_literals)
+    seen_placeholders: set[str] = set()
 
     for name, entry_data in raw.items():
         validate_secret_name(name)
@@ -264,6 +314,11 @@ def _build_config_from_dict(
                 f"Secret '{name}' is missing required key 'hosts'. "
                 f"Every secret must be scoped to specific destination hosts."
             )
+        if not isinstance(entry_data["value"], str):
+            raise TypeError(
+                f"Secret '{name}': 'value' must be a string, "
+                f"got {type(entry_data['value']).__name__}"
+            )
         if not isinstance(entry_data["hosts"], list):
             raise TypeError(
                 f"Secret '{name}': 'hosts' must be a list of hostnames, "
@@ -275,10 +330,28 @@ def _build_config_from_dict(
             )
 
         placeholder = entry_data.get("placeholder", generate_placeholder(name))
+        if not isinstance(placeholder, str):
+            raise TypeError(
+                f"Secret '{name}': 'placeholder' must be a string, "
+                f"got {type(placeholder).__name__}"
+            )
+        if not placeholder:
+            raise ValueError(f"Secret '{name}': 'placeholder' cannot be empty.")
+        if placeholder in seen_placeholders:
+            raise ValueError(
+                f"Duplicate placeholder detected: {placeholder!r}. "
+                "Each secret must have a unique placeholder."
+            )
+        seen_placeholders.add(placeholder)
 
         raw_hosts = entry_data["hosts"]
         sanitized_hosts = []
         for h in raw_hosts:
+            if not isinstance(h, str):
+                raise TypeError(
+                    f"Secret '{name}': all 'hosts' entries must be strings, "
+                    f"got {type(h).__name__}"
+                )
             h = _sanitize_host(h)
             _validate_host_pattern(h)
             sanitized_hosts.append(h)
@@ -298,6 +371,10 @@ def _build_config_from_dict(
 
     if allow_net:
         for host in allow_net:
+            if not isinstance(host, str):
+                raise TypeError(
+                    f"'allow_net' entries must be strings, got {type(host).__name__}"
+                )
             host = _sanitize_host(host)
             _validate_host_pattern(host)
             config.allowed_hosts.add(host)

--- a/src/secrets_proxy/launcher.py
+++ b/src/secrets_proxy/launcher.py
@@ -509,6 +509,7 @@ def run(
     try:
         # Step 7: Build environment for sandboxed process
         sandbox_env = os.environ.copy()
+        sandbox_env.pop("SECRETS_PROXY_CONFIG_JSON", None)
 
         # Placeholder env vars (secrets)
         sandbox_env.update(config.get_env_vars())
@@ -545,5 +546,4 @@ def run(
 
     finally:
         _cleanup()
-
 

--- a/src/secrets_proxy/launcher.py
+++ b/src/secrets_proxy/launcher.py
@@ -547,6 +547,3 @@ def run(
         _cleanup()
 
 
-def _get_addon_entry_path() -> str:
-    """Return the path to the production addon_entry.py module."""
-    return _ADDON_ENTRY_PATH

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest setup for local source imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_addon_entry.py
+++ b/tests/test_addon_entry.py
@@ -1,0 +1,175 @@
+"""Tests for addon_entry.py env loading and config roundtrip (#36)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from secrets_proxy.config import (
+    ProxyConfig,
+    SecretEntry,
+    load_config_from_dict,
+)
+
+
+class TestToEnvJson:
+    """Test ProxyConfig.to_env_json() serialization."""
+
+    def test_roundtrip_single_secret(self):
+        raw = {
+            "MY_KEY": {
+                "value": "sk-real",
+                "hosts": ["api.example.com"],
+            }
+        }
+        config = load_config_from_dict(raw)
+        env_json = config.to_env_json()
+        data = json.loads(env_json)
+
+        assert "secrets" in data
+        assert "allowed_hosts" in data
+        assert "api.example.com" in data["allowed_hosts"]
+
+        # Exactly one secret, keyed by placeholder
+        assert len(data["secrets"]) == 1
+        placeholder = list(data["secrets"].keys())[0]
+        assert placeholder.startswith("SECRETS_PROXY_PLACEHOLDER_")
+        info = data["secrets"][placeholder]
+        assert info["name"] == "MY_KEY"
+        assert info["value"] == "sk-real"
+        assert info["hosts"] == ["api.example.com"]
+
+    def test_roundtrip_multiple_secrets(self):
+        raw = {
+            "KEY_A": {"value": "val-a", "hosts": ["a.com"]},
+            "KEY_B": {"value": "val-b", "hosts": ["b.com", "*.b.com"]},
+        }
+        config = load_config_from_dict(raw)
+        data = json.loads(config.to_env_json())
+        assert len(data["secrets"]) == 2
+        names = {s["name"] for s in data["secrets"].values()}
+        assert names == {"KEY_A", "KEY_B"}
+
+    def test_allowed_hosts_sorted(self):
+        raw = {
+            "Z": {"value": "v", "hosts": ["z.com"]},
+            "A": {"value": "v", "hosts": ["a.com"]},
+        }
+        config = load_config_from_dict(raw)
+        data = json.loads(config.to_env_json())
+        assert data["allowed_hosts"] == sorted(data["allowed_hosts"])
+
+
+class TestLoadConfigFromDict:
+    """Test load_config_from_dict matches load_config behavior."""
+
+    def test_basic_load(self):
+        raw = {
+            "SECRET": {
+                "value": "real-value",
+                "hosts": ["api.example.com"],
+            }
+        }
+        config = load_config_from_dict(raw)
+        assert "SECRET" in config.secrets
+        assert config.secrets["SECRET"].value == "real-value"
+        assert "api.example.com" in config.allowed_hosts
+
+    def test_preserves_placeholder(self):
+        raw = {
+            "KEY": {
+                "value": "val",
+                "hosts": ["h.com"],
+                "placeholder": "CUSTOM_PLACEHOLDER_123",
+            }
+        }
+        config = load_config_from_dict(raw)
+        assert config.secrets["KEY"].placeholder == "CUSTOM_PLACEHOLDER_123"
+
+    def test_invalid_name_rejected(self):
+        raw = {"bad;name": {"value": "v", "hosts": ["h.com"]}}
+        with pytest.raises(ValueError, match="Invalid secret name"):
+            load_config_from_dict(raw)
+
+    def test_missing_hosts_rejected(self):
+        raw = {"KEY": {"value": "v"}}
+        with pytest.raises(ValueError, match="missing required key 'hosts'"):
+            load_config_from_dict(raw)
+
+    def test_allow_net_extra_hosts(self):
+        raw = {"KEY": {"value": "v", "hosts": ["a.com"]}}
+        config = load_config_from_dict(raw, allow_net=["extra.com"])
+        assert "extra.com" in config.allowed_hosts
+        assert "a.com" in config.allowed_hosts
+
+
+class TestAddonEntryLoadConfig:
+    """Test _load_config_from_env from addon_entry.
+
+    Note: addon_entry.py runs _load_config_from_env() at module level on
+    first import. We need to set the env var *before* triggering import,
+    and we need to reimport for each test that needs fresh module state.
+    """
+
+    def _fresh_load(self, monkeypatch, env_json: str) -> ProxyConfig:
+        """Set env var and reimport addon_entry to get a fresh _load_config_from_env call."""
+        import sys
+        import importlib
+
+        monkeypatch.setenv("SECRETS_PROXY_CONFIG_JSON", env_json)
+
+        # Remove cached module so reimport triggers module-level code
+        for mod_name in list(sys.modules):
+            if mod_name == "secrets_proxy.addon_entry" or mod_name.startswith("secrets_proxy.addon_entry."):
+                del sys.modules[mod_name]
+
+        mod = importlib.import_module("secrets_proxy.addon_entry")
+        # The module-level config is what _load_config_from_env produced
+        return mod.config
+
+    def test_loads_from_env_and_clears(self, monkeypatch):
+        raw = {
+            "MY_KEY": {"value": "sk-real", "hosts": ["api.example.com"]}
+        }
+        config = load_config_from_dict(raw)
+        env_json = config.to_env_json()
+
+        loaded = self._fresh_load(monkeypatch, env_json)
+
+        # Env var should be cleared after module init
+        assert "SECRETS_PROXY_CONFIG_JSON" not in os.environ
+
+        # Config should match
+        assert "MY_KEY" in loaded.secrets
+        assert loaded.secrets["MY_KEY"].value == "sk-real"
+        assert loaded.secrets["MY_KEY"].hosts == ["api.example.com"]
+        assert "api.example.com" in loaded.allowed_hosts
+
+    def test_placeholder_preserved_in_roundtrip(self, monkeypatch):
+        raw = {
+            "KEY": {
+                "value": "val",
+                "hosts": ["h.com"],
+            }
+        }
+        config = load_config_from_dict(raw)
+        original_placeholder = config.secrets["KEY"].placeholder
+        env_json = config.to_env_json()
+
+        loaded = self._fresh_load(monkeypatch, env_json)
+        assert loaded.secrets["KEY"].placeholder == original_placeholder
+
+    def test_missing_env_var_raises(self, monkeypatch):
+        import sys
+        import importlib
+
+        monkeypatch.delenv("SECRETS_PROXY_CONFIG_JSON", raising=False)
+
+        for mod_name in list(sys.modules):
+            if mod_name == "secrets_proxy.addon_entry":
+                del sys.modules[mod_name]
+
+        with pytest.raises(KeyError):
+            importlib.import_module("secrets_proxy.addon_entry")

--- a/tests/test_launcher_hardening.py
+++ b/tests/test_launcher_hardening.py
@@ -163,7 +163,7 @@ def test_startup_prints_recovery_hint(monkeypatch, tmp_path: Path, capsys) -> No
     monkeypatch.setattr(launcher, "_check_mitmdump", lambda: None)
     monkeypatch.setattr(launcher, "_generate_mitmproxy_ca_if_needed", lambda: None)
     monkeypatch.setattr(launcher, "setup_ca_trust", lambda _: (bundle_path, {}))
-    monkeypatch.setattr(launcher, "_create_addon_script", lambda _: (str(addon_path), {}))
+    monkeypatch.setattr(launcher, "_ADDON_ENTRY_PATH", str(addon_path))
     monkeypatch.setattr(launcher, "_setup_nftables", lambda *_: False)
     monkeypatch.setattr(launcher, "start_proxy", lambda *_, **__: _FakeProc(returncode=None))
     monkeypatch.setattr(launcher.subprocess, "Popen", lambda *_, **__: _FakeProc(returncode=None))


### PR DESCRIPTION
## Summary

- **Problem**: Three deployment paths (launcher.py, Docker entrypoint, Sprites shell script) each had simplified ~100-line copies of addon logic that were missing security features from `addon.py`: compression handling, JSON escaping, URL encoding, WebSocket blocking, Brotli fail-closed, and decompression limits. Every fix to addon.py widened this gap.
- **Solution**: Create `addon_entry.py` — a thin mitmproxy entry point that loads config from an env var and instantiates the real `SecretsProxyAddon`. Add an `init` CLI subcommand that shell scripts call to generate placeholders and sandbox env files. Delete ~425 lines of generated/inline addon code.

### Key changes

| File | Change |
|------|--------|
| `config.py` | Extract `_build_config_from_dict()`, add `load_config_from_dict()` + `ProxyConfig.to_env_json()` |
| `addon_entry.py` | **New** — thin mitmproxy `-s` entry point (65 lines) |
| `__main__.py` | Add `init` subcommand (`--config-json`, `--config-file`, `--sandbox-env`) |
| `launcher.py` | Delete `_create_addon_script()` (~170 lines), use `addon_entry.py` + env var |
| `docker/entrypoint.sh` | Replace ~110-line heredoc with ~10-line call to `secrets_proxy init` |
| `sprites/secrets-proxy-run.sh` | Same replacement |
| `test_addon_entry.py` | **New** — roundtrip, env loading, placeholder preservation tests |
| `test_launcher_hardening.py` | 1-line monkeypatch fix for removed function |

**Net: 425 lines deleted, 404 lines added (175 of which are tests). ~320 lines of duplicated production code eliminated.**

## Test plan

- [x] All 113 existing tests pass
- [x] `secrets-proxy init --config-json '...' --sandbox-env /tmp/test.sh` produces correct output
- [ ] Docker rebuild and escape test (defer to integration)
- [ ] Sprites rebuild and test (defer to integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)