### PR TITLE
PR #46 follow-up hardening fixes

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -143,15 +143,18 @@ trap cleanup EXIT
 echo "[secrets-proxy] Running as '$SANDBOX_USER': $*"
 echo "────────────────────────────────────────"
 
-# Source env vars and run as sandbox user
-su "$SANDBOX_USER" -c "
+# Source env vars and run as sandbox user without command-string interpolation.
+su "$SANDBOX_USER" -s /bin/bash -c '
+    set -euo pipefail
+    ca_bundle="$1"
+    shift
     source /tmp/sandbox_env.sh
-    export SSL_CERT_FILE=$CA_BUNDLE
-    export REQUESTS_CA_BUNDLE=$CA_BUNDLE
-    export NODE_EXTRA_CA_CERTS=$CA_BUNDLE
-    export CURL_CA_BUNDLE=$CA_BUNDLE
-    $*
-"
+    export SSL_CERT_FILE="$ca_bundle"
+    export REQUESTS_CA_BUNDLE="$ca_bundle"
+    export NODE_EXTRA_CA_CERTS="$ca_bundle"
+    export CURL_CA_BUNDLE="$ca_bundle"
+    exec "$@"
+' -- "$CA_BUNDLE" "$@"
 EXIT_CODE=$?
 
 echo "────────────────────────────────────────"

--- a/src/secrets_proxy/config.py
+++ b/src/secrets_proxy/config.py
@@ -57,6 +57,9 @@ def _validate_host_pattern(pattern: str) -> None:
     - Wildcards must start with '*.' (not just '*')
     - Hostname must use valid characters
     """
+    if not pattern:
+        raise ValueError("Host pattern cannot be empty.")
+
     if pattern.startswith("*"):
         if not pattern.startswith("*."):
             raise ValueError(
@@ -181,21 +184,62 @@ class ProxyConfig:
         having addon_entry.py manually build ProxyConfig internals.
         """
         data = json.loads(env_json)
-        config = cls(allow_ip_literals=data.get("allow_ip_literals", False))
-        secrets_data = data.get("secrets", {})
-        for placeholder, info in secrets_data.items():
-            entry = SecretEntry(
-                name=info["name"],
-                placeholder=placeholder,
-                value=info["value"],
-                hosts=info["hosts"],
-            )
-            config.secrets[info["name"]] = entry
-            config._placeholder_to_secret[placeholder] = entry
-            for host in info["hosts"]:
-                config.allowed_hosts.add(host)
 
-        for host in data.get("allowed_hosts", []):
+        if not isinstance(data, dict):
+            raise TypeError("Invalid env config: top-level JSON value must be an object.")
+
+        allow_ip_literals = data.get("allow_ip_literals", False)
+        if not isinstance(allow_ip_literals, bool):
+            raise TypeError("Invalid env config: 'allow_ip_literals' must be a boolean.")
+
+        secrets_data = data.get("secrets", {})
+        if not isinstance(secrets_data, dict):
+            raise TypeError("Invalid env config: 'secrets' must be an object.")
+
+        raw: dict[str, dict[str, object]] = {}
+        for placeholder, info in secrets_data.items():
+            if not isinstance(placeholder, str):
+                raise TypeError("Invalid env config: secret placeholder keys must be strings.")
+            if not placeholder:
+                raise ValueError("Invalid env config: secret placeholders cannot be empty.")
+            if not isinstance(info, dict):
+                raise TypeError(
+                    f"Invalid env config: secret entry for placeholder '{placeholder}' must be an object."
+                )
+
+            name = info.get("name")
+            if not isinstance(name, str):
+                raise TypeError(
+                    f"Invalid env config: secret entry for placeholder '{placeholder}' is missing string 'name'."
+                )
+            if name in raw:
+                raise ValueError(
+                    f"Invalid env config: duplicate secret name '{name}' across placeholders."
+                )
+            if "value" not in info or "hosts" not in info:
+                raise ValueError(
+                    f"Invalid env config: secret '{name}' must include 'value' and 'hosts'."
+                )
+
+            raw[name] = {
+                "value": info["value"],
+                "hosts": info["hosts"],
+                "placeholder": placeholder,
+            }
+
+        config = _build_config_from_dict(
+            raw,
+            allow_ip_literals=allow_ip_literals,
+        )
+
+        allowed_hosts = data.get("allowed_hosts", [])
+        if not isinstance(allowed_hosts, list):
+            raise TypeError("Invalid env config: 'allowed_hosts' must be a list.")
+        for host in allowed_hosts:
+            if not isinstance(host, str):
+                raise TypeError("Invalid env config: all allowed_hosts entries must be strings.")
+            host = _sanitize_host(host)
+            _validate_host_pattern(host)
             config.allowed_hosts.add(host)
 
         return config
@@ -239,7 +283,13 @@ def _build_config_from_dict(
     Shared implementation for load_config() and load_config_from_dict().
     All validation (secret names, host patterns) is applied here.
     """
+    if not isinstance(raw, dict):
+        raise TypeError(
+            f"Config must be a JSON object mapping secret names to entries, got {type(raw).__name__}."
+        )
+
     config = ProxyConfig(allow_ip_literals=allow_ip_literals)
+    seen_placeholders: set[str] = set()
 
     for name, entry_data in raw.items():
         validate_secret_name(name)
@@ -264,6 +314,11 @@ def _build_config_from_dict(
                 f"Secret '{name}' is missing required key 'hosts'. "
                 f"Every secret must be scoped to specific destination hosts."
             )
+        if not isinstance(entry_data["value"], str):
+            raise TypeError(
+                f"Secret '{name}': 'value' must be a string, "
+                f"got {type(entry_data['value']).__name__}"
+            )
         if not isinstance(entry_data["hosts"], list):
             raise TypeError(
                 f"Secret '{name}': 'hosts' must be a list of hostnames, "
@@ -275,10 +330,28 @@ def _build_config_from_dict(
             )
 
         placeholder = entry_data.get("placeholder", generate_placeholder(name))
+        if not isinstance(placeholder, str):
+            raise TypeError(
+                f"Secret '{name}': 'placeholder' must be a string, "
+                f"got {type(placeholder).__name__}"
+            )
+        if not placeholder:
+            raise ValueError(f"Secret '{name}': 'placeholder' cannot be empty.")
+        if placeholder in seen_placeholders:
+            raise ValueError(
+                f"Duplicate placeholder detected: {placeholder!r}. "
+                "Each secret must have a unique placeholder."
+            )
+        seen_placeholders.add(placeholder)
 
         raw_hosts = entry_data["hosts"]
         sanitized_hosts = []
         for h in raw_hosts:
+            if not isinstance(h, str):
+                raise TypeError(
+                    f"Secret '{name}': all 'hosts' entries must be strings, "
+                    f"got {type(h).__name__}"
+                )
             h = _sanitize_host(h)
             _validate_host_pattern(h)
             sanitized_hosts.append(h)
@@ -298,6 +371,10 @@ def _build_config_from_dict(
 
     if allow_net:
         for host in allow_net:
+            if not isinstance(host, str):
+                raise TypeError(
+                    f"'allow_net' entries must be strings, got {type(host).__name__}"
+                )
             host = _sanitize_host(host)
             _validate_host_pattern(host)
             config.allowed_hosts.add(host)

--- a/src/secrets_proxy/launcher.py
+++ b/src/secrets_proxy/launcher.py
@@ -509,6 +509,7 @@ def run(
     try:
         # Step 7: Build environment for sandboxed process
         sandbox_env = os.environ.copy()
+        sandbox_env.pop("SECRETS_PROXY_CONFIG_JSON", None)
 
         # Placeholder env vars (secrets)
         sandbox_env.update(config.get_env_vars())
@@ -545,5 +546,4 @@ def run(
 
     finally:
         _cleanup()
-
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest setup for local source imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SRC_PATH))


### PR DESCRIPTION
Summary:
- harden shell wrapper command execution to avoid su -c interpolation and preserve argv semantics
- write init --sandbox-env atomically via temp file + replace to avoid symlink/TOCTOU clobber risk
- strengthen ProxyConfig validation for env roundtrips (type checks, duplicate placeholder/name detection, host validation)
- strip SECRETS_PROXY_CONFIG_JSON from sandbox process env in launcher
- add regression tests for the above and force tests to import local src package

Validation:
- python -m pytest tests/ -q
